### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-
+matplotlib


### PR DESCRIPTION
matplotlib is imported in run_sim, but is not listed in requirements.txt. Should the user also install the requirements in bounce-viz? I can make a setup.py that does that.